### PR TITLE
Adding optional for ent URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY git/ git/
+COPY keygen/ keygen/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,12 @@ spec:
             secretKeyRef:
               name: github-controller-github-auth-token
               key: github-token
+        - name: GITHUB_ENTERPRISE_URL
+          valueFrom:
+            configMapKeyRef:
+              key: github-url
+              name: github-controller-github-enterprise-url
+              optional: true
         name: manager
         resources:
           limits:


### PR DESCRIPTION
With the Key type, we needed to include the keygen directory for compiling and adding an optional for enterprise urls.

Signed-off-by: Chris Hein <me@chrishein.com>